### PR TITLE
feat(semigroup): adds implementations of semigroup along with laws an…

### DIFF
--- a/packages/funland-laws/src/index.ts
+++ b/packages/funland-laws/src/index.ts
@@ -6,6 +6,7 @@
  * See LICENSE file in the project root for full license information.
  */
 
+export * from "./semigroup"
 export * from "./equiv"
 export * from "./setoid"
 export * from "./functor"

--- a/packages/funland-laws/src/semigroup.js.flow
+++ b/packages/funland-laws/src/semigroup.js.flow
@@ -1,0 +1,18 @@
+/*!
+ * Copyright (c) 2018 by The Funland Project Developers.
+ * Some rights reserved.
+ *
+ * Licensed under the MIT License.
+ * See LICENSE file in the project root for full license information.
+ */
+
+/* @flow */
+
+import { Semigroup } from "funland"
+import { Equiv } from "./equiv"
+
+declare export class SemigroupLaws<A> {
+  +F: Semigroup<A>;
+
+  associativity(x: A, y: A, z: A): Equiv<boolean>;
+}

--- a/packages/funland-laws/src/semigroup.ts
+++ b/packages/funland-laws/src/semigroup.ts
@@ -20,7 +20,7 @@ import { Equiv } from "./equiv"
 export class SemigroupLaws<A> {
   constructor(public readonly F: Semigroup<A>) {}
 
-  associativity(x: A, y: A, z: A): Equiv<boolean> {
+  associativity(x: A, y: A, z: A): Equiv<A> {
     return Equiv.of(
       this.F.concat(this.F.concat(x, y), z),
       this.F.concat(x, this.F.concat(y, z)))

--- a/packages/funland-laws/src/semigroup.ts
+++ b/packages/funland-laws/src/semigroup.ts
@@ -1,0 +1,28 @@
+/*!
+ * Copyright (c) 2018 by The Funland Project Developers.
+ * Some rights reserved.
+ *
+ * Licensed under the MIT License.
+ * See LICENSE file in the project root for full license information.
+ */
+
+import { Semigroup } from "funland"
+import { Equiv } from "./equiv"
+
+/**
+ * Type-class laws for `Semigroup`, as defined in the `funland`
+ * sub-project and in the `static-land` spec.
+ *
+ * Laws defined for `Semigroup`:
+ *
+ * 1. Associativity: Associativity: S.concat(S.concat(a, b), c) ≡ S.concat(a, S.concat(b, c))
+ */
+export class SemigroupLaws<A> {
+  constructor(public readonly F: Semigroup<A>) {}
+
+  associativity(x: A, y: A, z: A): Equiv<boolean> {
+    return Equiv.of(
+      this.F.concat(this.F.concat(x, y), z),
+      this.F.concat(x, this.F.concat(y, z)))
+  }
+}

--- a/packages/funland-laws/test-common/index.ts
+++ b/packages/funland-laws/test-common/index.ts
@@ -6,6 +6,7 @@
  * See LICENSE file in the project root for full license information.
  */
 
+export * from "./semigroup-tests"
 export * from "./setoid-tests"
 export * from "./functor-tests"
 export * from "./apply-tests"

--- a/packages/funland-laws/test-common/semigroup-tests.ts
+++ b/packages/funland-laws/test-common/semigroup-tests.ts
@@ -1,0 +1,23 @@
+/*!
+ * Copyright (c) 2018 by The Funland Project Developers.
+ * Some rights reserved.
+ *
+ * Licensed under the MIT License.
+ * See LICENSE file in the project root for full license information.
+ */
+
+import * as jv from "jsverify"
+import { Semigroup } from "funland"
+import { Equiv, SemigroupLaws } from "../src"
+
+export function semigroupCheck<A>(
+  genA: jv.Arbitrary<A>,
+  F: Semigroup<A>,
+  lawsRef?: Semigroup<A>) {
+
+  const laws = lawsRef || new SemigroupLaws<A>(F)
+  const eq = (p: Equiv<boolean>) => p.lh === p.rh
+
+  jv.property("semigroup.associativity", genA, genA, genA,
+    (x, y, z) => eq(laws.associativity(x, y, z)))
+}

--- a/packages/funland-laws/test/ts/semigroup-examples.ts
+++ b/packages/funland-laws/test/ts/semigroup-examples.ts
@@ -1,0 +1,24 @@
+/*!
+ * Copyright (c) 2018 by The Funland Project Developers.
+ * Some rights reserved.
+ *
+ * Licensed under the MIT License.
+ * See LICENSE file in the project root for full license information.
+ */
+
+import * as jv from "jsverify"
+import {
+  Semigroup
+} from "funland"
+
+export function StringSemigroup(): Semigroup<string> {
+  return {
+    concat: (x: string, y: string): string => x + y
+  }
+}
+
+export function NumberSemigroup(): Semigroup<number> {
+  return {
+    concat: (x: number, y: number): number => x + y
+  }
+}

--- a/packages/funland-laws/test/ts/semigroup.test.ts
+++ b/packages/funland-laws/test/ts/semigroup.test.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright (c) 2018 by The Funland Project Developers.
+ * Some rights reserved.
+ *
+ * Licensed under the MIT License.
+ * See LICENSE file in the project root for full license information.
+ */
+
+import * as jv from "jsverify"
+import { semigroupCheck } from "../../test-common"
+import { StringSemigroup, NumberSemigroup } from "./semigroup-examples"
+
+describe("Semigroup<string>", () => {
+  semigroupCheck(jv.string, StringSemigroup())
+})
+
+describe("Semigroup<number>", () => {
+  semigroupCheck(jv.number, NumberSemigroup())
+})

--- a/packages/funland/src/index.js.flow
+++ b/packages/funland/src/index.js.flow
@@ -9,6 +9,7 @@
 /* @flow */
 
 declare export * from "./kinds"
+declare export * from "./semigroup"
 declare export * from "./setoid"
 declare export * from "./functor"
 declare export * from "./apply"

--- a/packages/funland/src/index.ts
+++ b/packages/funland/src/index.ts
@@ -7,6 +7,7 @@
  */
 
 export * from "./kinds"
+export * from "./semigroup"
 export * from "./setoid"
 export * from "./functor"
 export * from "./apply"

--- a/packages/funland/src/semigroup.js.flow
+++ b/packages/funland/src/semigroup.js.flow
@@ -1,0 +1,13 @@
+/*!
+ * Copyright (c) 2018 by The Funland Project Developers.
+ * Some rights reserved.
+ *
+ * Licensed under the MIT License.
+ * See LICENSE file in the project root for full license information.
+ */
+
+/* @flow */
+
+export interface Semigroup<A> {
+  concat(x: A, y: A): A 
+}

--- a/packages/funland/src/semigroup.ts
+++ b/packages/funland/src/semigroup.ts
@@ -1,0 +1,24 @@
+/*!
+ * Copyright (c) 2018 by The Funland Project Developers.
+ * Some rights reserved.
+ *
+ * Licensed under the MIT License.
+ * See LICENSE file in the project root for full license information.
+ */
+
+/**
+ * The `Semigroup` type defines equality.
+ *
+ * Inspired by [Data.Semigroup](https://hackage.haskell.org/package/base/docs/Data-Semigroup.html)
+ * from Haskell.
+ *
+ * Instances must obey the following laws:
+ *
+ * 1. Associativity: Associativity: S.concat(S.concat(a, b), c) ≡ S.concat(a, S.concat(b, c))
+ *
+ * Equivalent with the `Semigroup` type-class in the
+ * [static-land]{@link https://github.com/rpominov/static-land/} spec.
+ */
+export interface Semigroup<A> {
+  concat(x: A, y: A): A
+}

--- a/packages/funland/test/ts/semigroup.test.ts
+++ b/packages/funland/test/ts/semigroup.test.ts
@@ -1,0 +1,24 @@
+/*!
+ * Copyright (c) 2018 by The Funland Project Developers.
+ * Some rights reserved.
+ *
+ * Licensed under the MIT License.
+ * See LICENSE file in the project root for full license information.
+ */
+
+import * as assert from "assert"
+import * as types from "../../src"
+import { HK } from "../../src"
+
+type Types =
+  types.Semigroup<string>
+
+const t: Types = {
+  concat: (x, y) => x + y
+}
+
+describe("semigroup type tests", () => {
+  it("semigroup", () => {
+    assert.ok(t.concat("x", "y") === "xy")
+  })
+})


### PR DESCRIPTION
Adds support for `Semigroup` as described in the Static Land spec: https://github.com/rpominov/static-land/blob/master/docs/spec.md#semigroup

I'd like this to be a trial run for future PRs, so please let me know if you'd like me to do anything differently. I read through the contributor guidelines, and followed your lead code-wise.

This relates to issue #9