### PR TITLE
Add Ord typeclass

### DIFF
--- a/packages/funland-laws/src/index.js.flow
+++ b/packages/funland-laws/src/index.js.flow
@@ -10,6 +10,7 @@
 
 declare export * from "./equiv"
 declare export * from "./setoid"
+declare export * from "./ord"
 declare export * from "./functor"
 declare export * from "./apply"
 declare export * from "./applicative"

--- a/packages/funland-laws/src/index.ts
+++ b/packages/funland-laws/src/index.ts
@@ -9,6 +9,7 @@
 export * from "./semigroup"
 export * from "./equiv"
 export * from "./setoid"
+export * from "./ord"
 export * from "./functor"
 export * from "./apply"
 export * from "./applicative"

--- a/packages/funland-laws/src/ord.js.flow
+++ b/packages/funland-laws/src/ord.js.flow
@@ -16,7 +16,7 @@ declare export class OrdLaws<A> extends SetoidLaws<A> {
   +F: Ord<A>;
 
   constructor(F: Ord<A>): OrdLaws<A>;
-  totality(x: A, y: A): Equiv<boolean>;
-  antisymmetry(x: A, y: A): Equiv<boolean>;
-  transitivity2(x: A, y: A, z: A): Equiv<boolean>;
+  ordTotality(x: A, y: A): Equiv<boolean>;
+  ordAntisymmetry(x: A, y: A): Equiv<boolean>;
+  ordTransitivity(x: A, y: A, z: A): Equiv<boolean>;
 }

--- a/packages/funland-laws/src/ord.js.flow
+++ b/packages/funland-laws/src/ord.js.flow
@@ -1,0 +1,22 @@
+/*!
+ * Copyright (c) 2018 by The Funland Project Developers.
+ * Some rights reserved.
+ *
+ * Licensed under the MIT License.
+ * See LICENSE file in the project root for full license information.
+ */
+
+/* @flow */
+
+import { Ord } from "funland"
+import { Equiv } from "./equiv"
+import { SetoidLaws } from "./setoid"
+
+declare export class OrdLaws<A> extends SetoidLaws<A> {
+  +F: Ord<A>;
+
+  constructor(F: Ord<A>): OrdLaws<A>;
+  totality(x: A, y: A): Equiv<boolean>;
+  antisymmetry(x: A, y: A): Equiv<boolean>;
+  transitivity2(x: A, y: A, z: A): Equiv<boolean>;
+}

--- a/packages/funland-laws/src/ord.ts
+++ b/packages/funland-laws/src/ord.ts
@@ -1,0 +1,45 @@
+/*!
+ * Copyright (c) 2018 by The Funland Project Developers.
+ * Some rights reserved.
+ *
+ * Licensed under the MIT License.
+ * See LICENSE file in the project root for full license information.
+ */
+
+import { Ord } from "funland"
+import { Equiv } from "./equiv"
+import { SetoidLaws } from "./setoid"
+
+/**
+ * Type-class laws for `Ord`, as defined in the `funland`
+ * sub-project and in the `static-land` spec.
+ *
+ * Laws defined for `Ord`:
+ *
+ * 1. Totality: `S.lte(a, b)` or `S.lte(b, a)`
+ * 2. Antisymmetry: if `S.lte(a, b)` and `S.lte(b, a)`, then `S.equals(a, b)`
+ * 3. Transitivity: if `S.lte(a, b)` and `S.lte(b, c)`, then `S.lte(a, c)`
+ */
+export class OrdLaws<A> extends SetoidLaws<A> {
+  constructor(public readonly F: Ord<A>) {
+    super(F)
+  }
+
+  totality(x: A, y: A): Equiv<boolean> {
+    return Equiv.of(
+      this.F.lte(x, y) || this.F.lte(y, x),
+      true)
+  }
+
+  antisymmetry(x: A, y: A): Equiv<boolean> {
+    return Equiv.of(
+      this.F.lte(x, y) && this.F.lte(y, x),
+      this.F.equals(x, y))
+  }
+
+  transitivity2(x: A, y: A, z: A): Equiv<boolean> {
+    return Equiv.of(
+      this.F.lte(x, y) && this.F.lte(y, z),
+      this.F.lte(x, y) && this.F.lte(x, z))
+  }
+}

--- a/packages/funland-laws/src/ord.ts
+++ b/packages/funland-laws/src/ord.ts
@@ -25,19 +25,19 @@ export class OrdLaws<A> extends SetoidLaws<A> {
     super(F)
   }
 
-  totality(x: A, y: A): Equiv<boolean> {
+  ordTotality(x: A, y: A): Equiv<boolean> {
     return Equiv.of(
       this.F.lte(x, y) || this.F.lte(y, x),
       true)
   }
 
-  antisymmetry(x: A, y: A): Equiv<boolean> {
+  ordAntisymmetry(x: A, y: A): Equiv<boolean> {
     return Equiv.of(
       this.F.lte(x, y) && this.F.lte(y, x),
       this.F.equals(x, y))
   }
 
-  transitivity2(x: A, y: A, z: A): Equiv<boolean> {
+  ordTransitivity(x: A, y: A, z: A): Equiv<boolean> {
     return Equiv.of(
       !(this.F.lte(x, y) && this.F.lte(y, z)) || this.F.lte(x, z),
       true)

--- a/packages/funland-laws/src/ord.ts
+++ b/packages/funland-laws/src/ord.ts
@@ -39,7 +39,7 @@ export class OrdLaws<A> extends SetoidLaws<A> {
 
   transitivity2(x: A, y: A, z: A): Equiv<boolean> {
     return Equiv.of(
-      this.F.lte(x, y) && this.F.lte(y, z),
-      this.F.lte(x, y) && this.F.lte(x, z))
+      !(this.F.lte(x, y) && this.F.lte(y, z)) || this.F.lte(x, z),
+      true)
   }
 }

--- a/packages/funland-laws/src/setoid.js.flow
+++ b/packages/funland-laws/src/setoid.js.flow
@@ -15,7 +15,7 @@ declare export class SetoidLaws<A> {
   +F: Setoid<A>;
 
   constructor(F: Setoid<A>): SetoidLaws<A>;
-  reflexivity(x: A, y: A): Equiv<boolean>;
-  symmetry(x: A, y: A): Equiv<boolean>;
-  transitivity(x: A, y: A, z: A): Equiv<boolean>;
+  setoidReflexivity(x: A, y: A): Equiv<boolean>;
+  setoidSymmetry(x: A, y: A): Equiv<boolean>;
+  setoidTransitivity(x: A, y: A, z: A): Equiv<boolean>;
 }

--- a/packages/funland-laws/src/setoid.ts
+++ b/packages/funland-laws/src/setoid.ts
@@ -22,15 +22,15 @@ import { Equiv } from "./equiv"
 export class SetoidLaws<A> {
   constructor(public readonly F: Setoid<A>) {}
 
-  reflexivity(a: A): Equiv<boolean> {
+  setoidReflexivity(a: A): Equiv<boolean> {
     return Equiv.of(this.F.equals(a, a), true)
   }
 
-  symmetry(x: A, y: A): Equiv<boolean> {
+  setoidSymmetry(x: A, y: A): Equiv<boolean> {
     return Equiv.of(this.F.equals(x, y), this.F.equals(y, x))
   }
 
-  transitivity(x: A, y: A, z: A): Equiv<boolean> {
+  setoidTransitivity(x: A, y: A, z: A): Equiv<boolean> {
     return Equiv.of(
       this.F.equals(x, y) && this.F.equals(y, z),
       this.F.equals(x, y) && this.F.equals(x, z))

--- a/packages/funland-laws/test-common/index.ts
+++ b/packages/funland-laws/test-common/index.ts
@@ -8,6 +8,7 @@
 
 export * from "./semigroup-tests"
 export * from "./setoid-tests"
+export * from "./ord-tests"
 export * from "./functor-tests"
 export * from "./apply-tests"
 export * from "./applicative-tests"

--- a/packages/funland-laws/test-common/ord-tests.ts
+++ b/packages/funland-laws/test-common/ord-tests.ts
@@ -25,11 +25,11 @@ export function ordCheck<A>(
   const eq = (p: Equiv<boolean>) => p.lh === p.rh
 
   jv.property("ord.totality", genA, genA,
-    (x, y) => eq(laws.totality(x, y)))
+    (x, y) => eq(laws.ordTotality(x, y)))
 
   jv.property("ord.antisymmetry", genA, genA,
-    (x, y) => eq(laws.antisymmetry(x, y)))
+    (x, y) => eq(laws.ordAntisymmetry(x, y)))
 
   jv.property("ord.transitivity", genA, genA, genA,
-    (x, y, z) => eq(laws.transitivity2(x, y, z)))
+    (x, y, z) => eq(laws.ordTransitivity(x, y, z)))
 }

--- a/packages/funland-laws/test-common/ord-tests.ts
+++ b/packages/funland-laws/test-common/ord-tests.ts
@@ -1,0 +1,35 @@
+/*!
+ * Copyright (c) 2018 by The Funland Project Developers.
+ * Some rights reserved.
+ *
+ * Licensed under the MIT License.
+ * See LICENSE file in the project root for full license information.
+ */
+
+import * as jv from "jsverify"
+import { Ord } from "funland"
+import { Equiv, OrdLaws } from "../src"
+import { setoidCheck } from "./setoid-tests"
+
+export function ordCheck<A>(
+  genA: jv.Arbitrary<A>,
+  F: Ord<A>,
+  lawsRef?: OrdLaws<A>,
+  includeSuperTypes: boolean = true) {
+
+  const laws = lawsRef || new OrdLaws<A>(F)
+  if (includeSuperTypes) {
+    setoidCheck(genA, F, laws)
+  }
+
+  const eq = (p: Equiv<boolean>) => p.lh === p.rh
+
+  jv.property("ord.totality", genA, genA,
+    (x, y) => eq(laws.totality(x, y)))
+
+  jv.property("ord.antisymmetry", genA, genA,
+    (x, y) => eq(laws.antisymmetry(x, y)))
+
+  jv.property("ord.transitivity", genA, genA, genA,
+    (x, y, z) => eq(laws.transitivity2(x, y, z)))
+}

--- a/packages/funland-laws/test-common/setoid-tests.ts
+++ b/packages/funland-laws/test-common/setoid-tests.ts
@@ -19,11 +19,11 @@ export function setoidCheck<A>(
   const eq = (p: Equiv<boolean>) => p.lh === p.rh
 
   jv.property("setoid.reflexivity", genA,
-    x => eq(laws.reflexivity(x)))
+    x => eq(laws.setoidReflexivity(x)))
 
   jv.property("setoid.symmetry", genA, genA,
-    (x, y) => eq(laws.symmetry(x, y)))
+    (x, y) => eq(laws.setoidSymmetry(x, y)))
 
   jv.property("setoid.transitivity", genA, genA, genA,
-    (x, y, z) => eq(laws.transitivity(x, y, z)))
+    (x, y, z) => eq(laws.setoidTransitivity(x, y, z)))
 }

--- a/packages/funland-laws/test/ts/box.ts
+++ b/packages/funland-laws/test/ts/box.ts
@@ -10,6 +10,7 @@ import * as jv from "jsverify"
 import {
   HK,
   Setoid,
+  Ord,
   Functor,
   Apply,
   Applicative,
@@ -36,9 +37,15 @@ export function right<L, R>(value: R): Either<L, R> {
   return { tag: "right", value }
 }
 
-export function BoxSetoid<A>(): Setoid<Box<A>> {
-  return {
-    equals: (x: Box<A>, y: Box<A>) => x.value === y.value
+export class BoxSetoid<A> implements Setoid<Box<A>> {
+  equals(x: Box<A>, y: Box<A>) {
+    return x.value === y.value
+  }
+}
+
+export class BoxOrd<A> extends BoxSetoid<A> implements Ord<Box<A>> {
+  lte(x: Box<A>, y: Box<A>) {
+    return x.value <= y.value
   }
 }
 

--- a/packages/funland-laws/test/ts/ord.test.ts
+++ b/packages/funland-laws/test/ts/ord.test.ts
@@ -7,9 +7,9 @@
  */
 
 import * as jv from "jsverify"
-import { setoidCheck } from "../../test-common"
-import { BoxArbitrary, BoxSetoid } from "./box"
+import { ordCheck } from "../../test-common"
+import { BoxArbitrary, BoxOrd } from "./box"
 
-describe("Setoid<Box>", () => {
-  setoidCheck(BoxArbitrary(jv.number), new BoxSetoid)
+describe("Ord<Box>", () => {
+  ordCheck(BoxArbitrary(jv.number), new BoxOrd)
 })

--- a/packages/funland/src/index.js.flow
+++ b/packages/funland/src/index.js.flow
@@ -11,6 +11,7 @@
 declare export * from "./kinds"
 declare export * from "./semigroup"
 declare export * from "./setoid"
+declare export * from "./ord"
 declare export * from "./functor"
 declare export * from "./apply"
 declare export * from "./applicative"

--- a/packages/funland/src/index.ts
+++ b/packages/funland/src/index.ts
@@ -9,6 +9,7 @@
 export * from "./kinds"
 export * from "./semigroup"
 export * from "./setoid"
+export * from "./ord"
 export * from "./functor"
 export * from "./apply"
 export * from "./applicative"

--- a/packages/funland/src/ord.js.flow
+++ b/packages/funland/src/ord.js.flow
@@ -1,0 +1,15 @@
+/*!
+ * Copyright (c) 2018 by The Funland Project Developers.
+ * Some rights reserved.
+ *
+ * Licensed under the MIT License.
+ * See LICENSE file in the project root for full license information.
+ */
+
+/* @flow */
+
+import { Setoid } from "./setoid"
+
+export interface Ord<A> extends Setoid<A> {
+  lte(a: A, b: A): boolean
+}

--- a/packages/funland/src/ord.ts
+++ b/packages/funland/src/ord.ts
@@ -1,0 +1,28 @@
+/*!
+ * Copyright (c) 2018 by The Funland Project Developers.
+ * Some rights reserved.
+ *
+ * Licensed under the MIT License.
+ * See LICENSE file in the project root for full license information.
+ */
+
+import { Setoid } from "./setoid"
+
+/**
+ * The `Ord` type defines total ordering.
+ *
+ * Inspired by [Data.Ord](https://hackage.haskell.org/package/base/docs/Data-Ord.html)
+ * from Haskell.
+ *
+ * Instances must obey the following laws:
+ *
+ * 1. Totality: `S.lte(a, b)` or `S.lte(b, a)`
+ * 2. Antisymmetry: if `S.lte(a, b)` and `S.lte(b, a)`, then `S.equals(a, b)`
+ * 3. Transitivity: if `S.lte(a, b)` and `S.lte(b, c)`, then `S.lte(a, c)`
+ *
+ * Equivalent with the `Ord` type-class in the
+ * [static-land]{@link https://github.com/rpominov/static-land/} spec.
+ */
+export interface Ord<A> extends Setoid<A> {
+  lte(a: A, b: A): boolean
+}


### PR DESCRIPTION
Can you explain why `ord.transitivity` throws error?
```
ord.transitivity:
     Error: Failed after 5 tests and 49 shrinks. rngState: 8abe652a37910cdf84; Counterexample: {"value":-7.833701914927715e-7}; {"value":0}; {"value":-7.077477587325021e-7};
```